### PR TITLE
empty ports binding if network mode is set to host

### DIFF
--- a/pwnbox/__main__.py
+++ b/pwnbox/__main__.py
@@ -228,7 +228,7 @@ def main():
 					dns=config['CONTAINER']['DNS_SERVERS'].split(','),
 					environment=env_vars,
 					hostname=config['CONTAINER']['HOSTNAME'],
-					ports=forwarded_ports,
+					ports=forwarded_ports if not bool(config['CONTAINER']['HOST_NETWORKING']) else {},
 					privileged=bool(config['CONTAINER']['PRIVILEGED']),
 					remove=bool(config['CONTAINER']['AUTO_REMOVE']),
 					name=config['CONTAINER']['NAME'],


### PR DESCRIPTION
With `network_mode='host'` I get the following exception:

```bash
Traceback (most recent call last):
  File "/home/tm/.local/bin/pwnbox", line 33, in <module>
    sys.exit(load_entry_point('pwnbox==1.5.1', 'console_scripts', 'pwnbox')())
  File "/home/tm/.local/lib/python3.9/site-packages/pwnbox-1.5.1-py3.9.egg/pwnbox/__main__.py", line 223, in main
    container_id = client.containers.run(
  File "/home/tm/.local/lib/python3.9/site-packages/docker-5.0.0-py3.9.egg/docker/models/containers.py", line 811, in run
    container = self.create(image=image, command=command,
  File "/home/tm/.local/lib/python3.9/site-packages/docker-5.0.0-py3.9.egg/docker/models/containers.py", line 869, in create
    create_kwargs = _create_container_args(kwargs)
  File "/home/tm/.local/lib/python3.9/site-packages/docker-5.0.0-py3.9.egg/docker/models/containers.py", line 1087, in _create_container_args
    create_kwargs['host_config'] = HostConfig(**host_config_kwargs)
  File "/home/tm/.local/lib/python3.9/site-packages/docker-5.0.0-py3.9.egg/docker/types/containers.py", line 338, in __init__
    raise host_config_incompatible_error(
docker.errors.InvalidArgument: "host" network_mode is incompatible with port_bindings
```

To solve it I empty ports parameter if `network_mode='host'`. `network_mode='host'` isn't support in combination with `ports` or `network`. Have a look at https://docker-py.readthedocs.io/en/stable/containers.html:

**network_mode** (str) –
One of:

_bridge_ Create a new network stack for the container on on the bridge network.
_none_ No networking for this container.
_container:<name|id>_ Reuse another container’s network stack.
_host_ Use the host network stack. **This mode is incompatible with ports.
Incompatible with network.**
